### PR TITLE
Changed <angled> include to "quotes" in `bench.h`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
 CFLAGS=-Wall -I. -O2 -DNDEBUG -std=c99
-LDFLAGS=-lpthread -ldl -lm -static
 SRCS=$(wildcard *.c)
 OBJS=$(SRCS:.c=.o)
 HDRS=$(wildcard *.h)
 TARGET=sqlite-bench
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	LDFLAGS=-lpthread -ldl -lm
+else
+	LDFLAGS=-lpthread -ldl -lm -static
+endif
+
+
 $(TARGET): $(OBJS)
-	$(CC) -o $@ $^ $(LDFLAGS)
+	$(CC) $(OBJS) -o $(TARGET) $(LDFLAGS)
+
+%.o : %.c 
+	$(CC) -c $<
 
 $(OBJS): $(HDRS)
 

--- a/bench.h
+++ b/bench.h
@@ -16,7 +16,7 @@
 #include <string.h>
 #include <sys/time.h>
 #include <time.h>
-#include <sqlite3.h>
+#include "sqlite3.h"
 
 #define kNumBuckets 154
 #define kNumData 1000000


### PR DESCRIPTION
The original header file may cause clang crash in some versions.
The Sqlite3 is not a system program, so using quotes here will make more sense.